### PR TITLE
fix: prevent DCS crash in blastWave when getDesc() called on damaged statics

### DIFF
--- a/Splash_Damage_3.4.2_Standard_With_Ground_Ordnance.lua
+++ b/Splash_Damage_3.4.2_Standard_With_Ground_Ordnance.lua
@@ -6952,6 +6952,11 @@ function blastWave(_point, _radius, weapon, power, isShapedCharge)
     }
   
     local ifFound = function(foundObject, val)
+        local category = foundObject:getCategory()
+        -- Calling getDesc() on a damaged static or scenery object crashes DCS via
+        -- regLuaStaticObject -> luaD_growstack overflow -> memmove ACCESS_VIOLATION.
+        -- Skip these categories entirely before any further API calls.
+        if category == Object.Category.STATIC or category == Object.Category.SCENERY then return true end
         if foundObject:getDesc().category == Unit.Category.GROUND_UNIT and foundObject:getCategory() == Object.Category.UNIT then
             foundUnits[#foundUnits + 1] = foundObject
         end
@@ -7094,8 +7099,8 @@ function blastWave(_point, _radius, weapon, power, isShapedCharge)
         debugMsg("Scanning for objects within " .. _radius .. "m radius")
     end
     world.searchObjects(Object.Category.UNIT, volS, ifFound)
-    world.searchObjects(Object.Category.STATIC, volS, ifFound)
-    world.searchObjects(Object.Category.SCENERY, volS, ifFound)
+    --world.searchObjects(Object.Category.STATIC, volS, ifFound)   -- disabled: getDesc() on damaged statics crashes DCS (ACCESS_VIOLATION via regLuaStaticObject)
+    --world.searchObjects(Object.Category.SCENERY, volS, ifFound)  -- disabled: same crash risk as STATIC
     world.searchObjects(Object.Category.CARGO, volS, ifFound)
     if splash_damage_options.debug then
         debugMsg("Found " .. #foundUnits .. " ground units for damage modeling")

--- a/Splash_Damage_3.4_Basic.lua
+++ b/Splash_Damage_3.4_Basic.lua
@@ -6919,6 +6919,11 @@ function blastWave(_point, _radius, weapon, power, isShapedCharge)
     }
   
     local ifFound = function(foundObject, val)
+        local category = foundObject:getCategory()
+        -- Calling getDesc() on a damaged static or scenery object crashes DCS via
+        -- regLuaStaticObject -> luaD_growstack overflow -> memmove ACCESS_VIOLATION.
+        -- Skip these categories entirely before any further API calls.
+        if category == Object.Category.STATIC or category == Object.Category.SCENERY then return true end
         if foundObject:getDesc().category == Unit.Category.GROUND_UNIT and foundObject:getCategory() == Object.Category.UNIT then
             foundUnits[#foundUnits + 1] = foundObject
         end
@@ -7061,8 +7066,8 @@ function blastWave(_point, _radius, weapon, power, isShapedCharge)
         debugMsg("Scanning for objects within " .. _radius .. "m radius")
     end
     world.searchObjects(Object.Category.UNIT, volS, ifFound)
-    world.searchObjects(Object.Category.STATIC, volS, ifFound)
-    world.searchObjects(Object.Category.SCENERY, volS, ifFound)
+    --world.searchObjects(Object.Category.STATIC, volS, ifFound)   -- disabled: getDesc() on damaged statics crashes DCS (ACCESS_VIOLATION via regLuaStaticObject)
+    --world.searchObjects(Object.Category.SCENERY, volS, ifFound)  -- disabled: same crash risk as STATIC
     world.searchObjects(Object.Category.CARGO, volS, ifFound)
     if splash_damage_options.debug then
         debugMsg("Found " .. #foundUnits .. " ground units for damage modeling")

--- a/Splash_Damage_3.4_Standard.lua
+++ b/Splash_Damage_3.4_Standard.lua
@@ -6919,6 +6919,11 @@ function blastWave(_point, _radius, weapon, power, isShapedCharge)
     }
   
     local ifFound = function(foundObject, val)
+        local category = foundObject:getCategory()
+        -- Calling getDesc() on a damaged static or scenery object crashes DCS via
+        -- regLuaStaticObject -> luaD_growstack overflow -> memmove ACCESS_VIOLATION.
+        -- Skip these categories entirely before any further API calls.
+        if category == Object.Category.STATIC or category == Object.Category.SCENERY then return true end
         if foundObject:getDesc().category == Unit.Category.GROUND_UNIT and foundObject:getCategory() == Object.Category.UNIT then
             foundUnits[#foundUnits + 1] = foundObject
         end
@@ -7061,8 +7066,8 @@ function blastWave(_point, _radius, weapon, power, isShapedCharge)
         debugMsg("Scanning for objects within " .. _radius .. "m radius")
     end
     world.searchObjects(Object.Category.UNIT, volS, ifFound)
-    world.searchObjects(Object.Category.STATIC, volS, ifFound)
-    world.searchObjects(Object.Category.SCENERY, volS, ifFound)
+    --world.searchObjects(Object.Category.STATIC, volS, ifFound)   -- disabled: getDesc() on damaged statics crashes DCS (ACCESS_VIOLATION via regLuaStaticObject)
+    --world.searchObjects(Object.Category.SCENERY, volS, ifFound)  -- disabled: same crash risk as STATIC
     world.searchObjects(Object.Category.CARGO, volS, ifFound)
     if splash_damage_options.debug then
         debugMsg("Found " .. #foundUnits .. " ground units for damage modeling")

--- a/Splash_Damage_3.4_Standard_With_Ground_Ordnance.lua
+++ b/Splash_Damage_3.4_Standard_With_Ground_Ordnance.lua
@@ -6919,6 +6919,11 @@ function blastWave(_point, _radius, weapon, power, isShapedCharge)
     }
   
     local ifFound = function(foundObject, val)
+        local category = foundObject:getCategory()
+        -- Calling getDesc() on a damaged static or scenery object crashes DCS via
+        -- regLuaStaticObject -> luaD_growstack overflow -> memmove ACCESS_VIOLATION.
+        -- Skip these categories entirely before any further API calls.
+        if category == Object.Category.STATIC or category == Object.Category.SCENERY then return true end
         if foundObject:getDesc().category == Unit.Category.GROUND_UNIT and foundObject:getCategory() == Object.Category.UNIT then
             foundUnits[#foundUnits + 1] = foundObject
         end
@@ -7061,8 +7066,8 @@ function blastWave(_point, _radius, weapon, power, isShapedCharge)
         debugMsg("Scanning for objects within " .. _radius .. "m radius")
     end
     world.searchObjects(Object.Category.UNIT, volS, ifFound)
-    world.searchObjects(Object.Category.STATIC, volS, ifFound)
-    world.searchObjects(Object.Category.SCENERY, volS, ifFound)
+    --world.searchObjects(Object.Category.STATIC, volS, ifFound)   -- disabled: getDesc() on damaged statics crashes DCS (ACCESS_VIOLATION via regLuaStaticObject)
+    --world.searchObjects(Object.Category.SCENERY, volS, ifFound)  -- disabled: same crash risk as STATIC
     world.searchObjects(Object.Category.CARGO, volS, ifFound)
     if splash_damage_options.debug then
         debugMsg("Found " .. #foundUnits .. " ground units for damage modeling")

--- a/Splash_Damage_main.lua
+++ b/Splash_Damage_main.lua
@@ -6953,6 +6953,11 @@ function blastWave(_point, _radius, weapon, power, isShapedCharge)
     }
   
     local ifFound = function(foundObject, val)
+        local category = foundObject:getCategory()
+        -- Calling getDesc() on a damaged static or scenery object crashes DCS via
+        -- regLuaStaticObject -> luaD_growstack overflow -> memmove ACCESS_VIOLATION.
+        -- Skip these categories entirely before any further API calls.
+        if category == Object.Category.STATIC or category == Object.Category.SCENERY then return true end
         if foundObject:getDesc().category == Unit.Category.GROUND_UNIT and foundObject:getCategory() == Object.Category.UNIT then
             foundUnits[#foundUnits + 1] = foundObject
         end
@@ -7095,8 +7100,8 @@ function blastWave(_point, _radius, weapon, power, isShapedCharge)
         debugMsg("Scanning for objects within " .. _radius .. "m radius")
     end
     world.searchObjects(Object.Category.UNIT, volS, ifFound)
-    world.searchObjects(Object.Category.STATIC, volS, ifFound)
-    world.searchObjects(Object.Category.SCENERY, volS, ifFound)
+    --world.searchObjects(Object.Category.STATIC, volS, ifFound)   -- disabled: getDesc() on damaged statics crashes DCS (ACCESS_VIOLATION via regLuaStaticObject)
+    --world.searchObjects(Object.Category.SCENERY, volS, ifFound)  -- disabled: same crash risk as STATIC
     world.searchObjects(Object.Category.CARGO, volS, ifFound)
     if splash_damage_options.debug then
         debugMsg("Found " .. #foundUnits .. " ground units for damage modeling")


### PR DESCRIPTION
## Summary

- `blastWave`'s `ifFound` callback calls `getDesc()` on every object returned by `world.searchObjects`, including `Object.Category.STATIC` and `Object.Category.SCENERY` objects
- Calling `getDesc()` on a recently-hit static or scenery object triggers a C-level stack overflow inside DCS's `regLuaStaticObject`, which propagates as `ACCESS_VIOLATION` in `VCRUNTIME140.dll` (`memmove+0x181`)
- This crash **cannot be caught by `pcall`** — it originates below the Lua layer in the engine

## Crash stack (from production log)

```
# C0000005 ACCESS_VIOLATION
memmove + 0x181          (VCRUNTIME140)
luaD_growstack           (repeated — Lua stack exhausted)
lua_pcall
ED_lua_pcall
Scripting::regLuaStaticObject + 0x83B
```

Reproduced twice on DCS 2.9.25.21123 MT server:
1. AH-64D Hellfires hitting static objects (`Allies_Director`, `flak41`)
2. F-16C Mk-82s hitting SA-75 site components (`S_75M_Volhov`, `SNR_75V`, `RD_75`) — these are ground-typed units but DCS routes them through `regLuaStaticObject` internally, so removing the STATIC `searchObjects` call alone was not sufficient

## Fix

Add a category pre-check at the **top** of the `blastWave` `ifFound` callback, before any `getDesc()` call:

```lua
local ifFound = function(foundObject, val)
    local category = foundObject:getCategory()
    -- Calling getDesc() on a damaged static or scenery object crashes DCS via
    -- regLuaStaticObject -> luaD_growstack overflow -> memmove ACCESS_VIOLATION.
    -- Skip these categories entirely before any further API calls.
    if category == Object.Category.STATIC or category == Object.Category.SCENERY then return true end
    ...
```

Also comment out the `world.searchObjects` calls for `STATIC` and `SCENERY` at the bottom of `blastWave`, since the guard makes them no-ops anyway.

**Confirmed fix:** 37+ hours clean uptime on the same server/mission after the guard was added, with active combat including the weapon types and target types that caused both previous crashes.

## Trade-off

The `static_damage_boost` cascade wave explosions on nearby statics are no longer applied via `blastWave`. The initial `trigger.action.explosion` still damages statics normally. If cascade behaviour on statics is wanted in the future, the safe approach is to pre-cache static positions/sizes at mission load via `coalition.getStaticObjects()` and use that cached data instead of live API calls.

## Files changed

All active 3.4.x variants and `main.lua`:
- `Splash_Damage_3.4_Basic.lua`
- `Splash_Damage_3.4_Standard.lua`
- `Splash_Damage_3.4_Standard_With_Ground_Ordnance.lua`
- `Splash_Damage_3.4.2_Standard_With_Ground_Ordnance.lua`
- `Splash_Damage_main.lua`